### PR TITLE
Safer call to sparse()

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -421,7 +421,7 @@ function MOI.optimize!(optimizer::Optimizer)
     cone = optimizer.cone
     m = optimizer.data.m
     n = optimizer.data.n
-    A = sparse(optimizer.data.I, optimizer.data.J, optimizer.data.V)
+    A = sparse(optimizer.data.I, optimizer.data.J, optimizer.data.V, m, n)
     b = optimizer.data.b
     objective_constant = optimizer.data.objective_constant
     c = optimizer.data.c


### PR DESCRIPTION
Without specifying `m`, and `n`, sparse can return a matrix of the wrong dimensions if there are empty columns or rows. In particular for CSC matrices, this could cause a crash if the last column is empty.