### PR TITLE
Explain why installation failed for users with incompatible Julia binary

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -81,17 +81,6 @@ if !custom_library
         # Download and install binaries
         install(dl_info...; prefix=prefix, force=true, verbose=verbose)
     end
-
-    usable(p) = satisfied(p; verbose=verbose, isolate=true)
-    failed = [p.libnames for p in products if !usable(p)]
-    if !isempty(failed)
-        error(
-            "The following dependencies could not be satisfied by binaries " *
-            "from BinaryProvider: \n$failed.\nIn case You are using non-" *
-            "official Julia binaries, try compiling SCS from source.\nMake " *
-            "sure Julia and SCS are linked against the same OpenBLAS library.\n"
-        )
-    end
 end
 
 # Write out a deps.jl file that will contain mappings for our products

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -76,7 +76,18 @@ if !custom_library
         # Download and install binaries
         install(dl_info...; prefix=prefix, force=true, verbose=verbose)
     end
+
+    usable(p) = satisfied(p; verbose=verbose, isolate=true)
+    failed = [p.libnames for p in products if !usable(p)]
+    if !isempty(failed)
+        error(
+            "The following dependencies could not be satisfied by binaries " *
+            "from BinaryProvider: \n$failed.\nIn case You are using non-" *
+            "official Julia binaries, try installing SCS from source.\nMake " *
+            "sure Julia and SCS are linked against the same OpenBLAS library."
+        )
+    end
 end
 
 # Write out a deps.jl file that will contain mappings for our products
-write_deps_file(joinpath(@__DIR__, "deps.jl"), products, verbose=verbose)
+#write_deps_file(joinpath(@__DIR__, "deps.jl"), products, verbose=verbose)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,10 @@
 using BinaryProvider, Libdl # requires BinaryProvider 0.3.0 or later
 
+if !(haskey(ENV, "JULIA_SCS_LIBRARY_PATH") || VERSION < v"1.3")
+    @info("Installing default SCS binaries")
+    exit(0)
+end
+
 ## NOTE: This is not a typical build.jl file; it has extra stuff toward the bottom.
 ## Don't just replace this file with the output of a BinaryBuilder repository!
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,9 @@
-using BinaryProvider, Libdl # requires BinaryProvider 0.3.0 or later
-
 if !(haskey(ENV, "JULIA_SCS_LIBRARY_PATH") || VERSION < v"1.3")
     @info("Installing default SCS binaries")
     exit(0)
 end
+
+using BinaryProvider, Libdl # requires BinaryProvider 0.3.0 or later
 
 ## NOTE: This is not a typical build.jl file; it has extra stuff toward the bottom.
 ## Don't just replace this file with the output of a BinaryBuilder repository!

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -83,11 +83,11 @@ if !custom_library
         error(
             "The following dependencies could not be satisfied by binaries " *
             "from BinaryProvider: \n$failed.\nIn case You are using non-" *
-            "official Julia binaries, try installing SCS from source.\nMake " *
-            "sure Julia and SCS are linked against the same OpenBLAS library."
+            "official Julia binaries, try compiling SCS from source.\nMake " *
+            "sure Julia and SCS are linked against the same OpenBLAS library.\n"
         )
     end
 end
 
 # Write out a deps.jl file that will contain mappings for our products
-#write_deps_file(joinpath(@__DIR__, "deps.jl"), products, verbose=verbose)
+write_deps_file(joinpath(@__DIR__, "deps.jl"), products, verbose=verbose)


### PR DESCRIPTION
Looking properly at issue https://github.com/jump-dev/SCS.jl/issues/194#issue-673098930, I have realized it is not a problem with `SCS.jl`. The reason for failure to install is caused simply by running unsupported Julia binaries -- such as those linked against OpenBLAS different from the one used by `scsindir.so` from BinaryProvider.

While this is **clearly** mentioned in `README.md`, when a user tries to install `SCS.jl` the easy way first, they get: 
```
ERROR: LoadError: LibraryProduct(nothing, ["libscsindir"], :indirect, "Prefix(/home/user/.julia/packages/SCS/28Svy/deps/usr)") is not satisfied, cannot generate deps.jl!
```
At this point, it is not obvious that it is the users fault.

The user could try to debug the problem by adding `--verbose` to `ARGS`. They would, unfortunately, not be aware that such an option exists, nor would they know how to do so. Even if they manage it, the last line of `BinaryProvider`'s output clearly states:
```
Info: Could not locate libscsindir inside /home/user/projects/usr/lib
```
just before throwing an error. This is both incorrect and makes it harder to spot messages such as:
```
libopenblas64_.so: cannot open shared object file: No such file or directory
```
which is the real reason for failure.


I consider this more of a paper-cut issue, relevant only to _unsupported_ installations, and would understand if you do not wish to include the error message.