### PR TITLE
Conic form supports variable primal

### DIFF
--- a/src/geometric.jl
+++ b/src/geometric.jl
@@ -54,6 +54,13 @@ function rows(model::GeometricConicForm, ci::CI{MOI.VectorAffineFunction{Float64
     return ci.value .+ (1:model.dimension[ci.value])
 end
 
+function MOI.supports(
+    ::GeometricConicForm,
+    ::MOI.VariablePrimalStart,
+    ::Type{MOI.VariableIndex},
+)
+    return true
+end
 function MOI.set(::GeometricConicForm, ::MOI.VariablePrimalStart,
                  ::MOI.VariableIndex, ::Nothing)
 end

--- a/src/geometric.jl
+++ b/src/geometric.jl
@@ -68,6 +68,13 @@ function MOI.set(model::GeometricConicForm, ::MOI.VariablePrimalStart,
                  vi::MOI.VariableIndex, value::Float64)
     model.primal[vi.value] = value
 end
+function MOI.supports(
+    ::GeometricConicForm,
+    ::MOI.ConstraintPrimalStart,
+    ::Type{<:MOI.ConstraintIndex},
+)
+    return true
+end
 function MOI.set(::GeometricConicForm, ::MOI.ConstraintPrimalStart,
                  ::MOI.ConstraintIndex, ::Nothing)
 end
@@ -75,6 +82,14 @@ function MOI.set(model::GeometricConicForm, ::MOI.ConstraintPrimalStart,
                  ci::MOI.ConstraintIndex, value)
     offset = constroffset(model, ci)
     model.slack[rows(model, ci)] .= value
+end
+
+function MOI.supports(
+    ::GeometricConicForm,
+    ::MOI.ConstraintDualStart,
+    ::Type{<:MOI.ConstraintIndex},
+)
+    return true
 end
 function MOI.set(::GeometricConicForm, ::MOI.ConstraintDualStart,
                   ::MOI.ConstraintIndex, ::Nothing)


### PR DESCRIPTION
We're calling `copy_to` to this `GeometricConicForm` directly:
https://github.com/jump-dev/SCS.jl/blob/7669c8df10a71da367e6bf7fe37a3ee7aba144a1/src/MOI_wrapper.jl#L146
 so it needs to implement `supports` otherwise the starting values are not copied and we get the warning
```
┌ Warning: MathOptInterface.VariablePrimalStart() is not supported by SCS.GeometricConicForm{Float64, SCS.SparseMatrixCSRtoCSC{Int64}, NTuple{8, DataType}}. This information will be discarded.
```