### PR TITLE
update to scs-3.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,9 @@ julia = "1"
 
 [extras]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Compat", "Pkg"]
+test = ["Test", "Compat", "Pkg", "DelimitedFiles"]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -257,7 +257,10 @@ function MOI.optimize!(optimizer::Optimizer)
     linear_solver, options = sanitize_SCS_options(options)
 
     cone = optimizer.cone
-    sol = SCS_solve(linear_solver, m, n, _managed_matrix(data.A), b, c,
+    sol = SCS_solve(linear_solver, m, n,
+                    _managed_matrix(data.A),
+                    ManagedSCSMatrix{scsint_t(linear_solver)}(n, n, spzeros(n,n)),
+                    b, c,
                     data.num_rows[1], data.num_rows[2], Float64[], Float64[],
                     cone.qa, cone.sa, div(data.num_rows[5], 3), div(data.num_rows[6], 3), cone.p,
                     data.primal, data.dual, data.slack; options...)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -258,9 +258,9 @@ function MOI.optimize!(optimizer::Optimizer)
 
     cone = optimizer.cone
     sol = SCS_solve(linear_solver, m, n, _managed_matrix(data.A), b, c,
-                    data.num_rows[1], data.num_rows[2], cone.qa, cone.sa, div(data.num_rows[5], 3), div(data.num_rows[6], 3), cone.p,
-                    data.primal, data.dual,
-                    data.slack; options...)
+                    data.num_rows[1], data.num_rows[2], Float64[], Float64[],
+                    cone.qa, cone.sa, div(data.num_rows[5], 3), div(data.num_rows[6], 3), cone.p,
+                    data.primal, data.dual, data.slack; options...)
 
     data.primal = sol.x
     data.dual = sol.y

--- a/src/MPB_wrapper.jl
+++ b/src/MPB_wrapper.jl
@@ -104,8 +104,9 @@ const status_map = Dict{Int, Symbol}(
 function optimize!(m::SCSMathProgModel)
     linear_solver, options = sanitize_SCS_options(m.options)
     t = time()
-    solution = SCS_solve(linear_solver, m.m, m.n, m.A, m.b, m.c, m.f, m.l, m.q,
-                         m.s, m.ep, m.ed, Float64[],
+    solution = SCS_solve(linear_solver, m.m, m.n, m.A, m.b, m.c,
+                         m.f, m.l, Float64[], Float64[],
+                         m.q, m.s, m.ep, m.ed, Float64[],
                          m.primal_sol, m.dual_sol, m.slack; options...)
     m.solve_time = time() - t
 

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -13,9 +13,8 @@ if haskey(ENV, "JULIA_SCS_LIBRARY_PATH") || VERSION < v"1.3"
 
     function __init__()
         vnum = VersionNumber(SCS_version())
-        depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
-        if vnum < v"2.1.0"
-            error("Current SCS version installed is $vnum, but we require version 2.1.*")
+        if vnum < v"3.0.0"
+            error("Current SCS version installed is $vnum, but we require version 3.0.*")
         end
     end
 else

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -4,6 +4,7 @@ using Libdl
 using Requires
 
 if haskey(ENV, "JULIA_SCS_LIBRARY_PATH") || VERSION < v"1.3"
+    haskey(ENV, "JULIA_SCS_LIBRARY_PATH") && @info "using local SCS libraries at $(ENV["JULIA_SCS_LIBRARY_PATH"])"
     if isfile(joinpath(dirname(@__FILE__), "..", "deps", "deps.jl"))
         include(joinpath(dirname(@__FILE__), "..", "deps", "deps.jl"))
     else

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -33,10 +33,21 @@ export SCS_init, SCS_solve, SCS_finish, SCS_version
 #
 # Returns a Solution object.
 function SCS_solve(linear_solver::Type{<:LinearSolver},
-        m::Integer, n::Integer, A::ManagedSCSMatrix{T}, b::Vector{Float64}, c::Vector{Float64},
-        f::Integer, l::Integer, bu::Vector{Float64}, bl::Vector{Float64},
-        q::Vector{<:Integer}, s::Vector{<:Integer},
-        ep::Integer, ed::Integer, p::Vector{Float64},
+        m::Integer,
+        n::Integer,
+        A::ManagedSCSMatrix{T},
+        P::ManagedSCSMatrix{T},
+        b::Vector{Float64},
+        c::Vector{Float64},
+        f::Integer,
+        l::Integer,
+        bu::Vector{Float64},
+        bl::Vector{Float64},
+        q::Vector{<:Integer},
+        s::Vector{<:Integer},
+        ep::Integer,
+        ed::Integer,
+        p::Vector{Float64},
         primal_sol::Vector{Float64}=zeros(n),
         dual_sol::Vector{Float64}=zeros(m),
         slack::Vector{Float64}=zeros(m);
@@ -68,13 +79,16 @@ function SCS_solve(linear_solver::Type{<:LinearSolver},
     solution = SCSSolution(pointer(primal_sol), pointer(dual_sol), pointer(slack))
 
     settings = Base.cconvert(Ref{SCSSettings{T}}, SCSSettings(linear_solver; options...))
-    P = ManagedSCSMatrix{T}(n, n, spzeros(n,n))
+    # settings potentially hold pointers to strings from options that need to be protected from GC
 
     data = SCSData(m, n, A, P, b, c, settings)
     # data holds pointers to objects which need to be protected from GC:
     # A, P, b, c and settings
 
     cone = SCSCone{T}(f, l, bu, bl, q_T, s_T, ep, ed, p)
+    # cone holds pointers to objects which need to be protected from GC:
+    # bu, bl, q_T, s_T, p
+
     info_ref = Base.cconvert(Ref{SCSInfo{T}}, SCSInfo{T}())
 
     Base.GC.@preserve A P b c settings bu bl q_T s_T p options begin
@@ -86,19 +100,53 @@ function SCS_solve(linear_solver::Type{<:LinearSolver},
     return Solution(primal_sol, dual_sol, slack, info_ref[], status)
 end
 function SCS_solve(linear_solver::Type{<:LinearSolver},
-        m::Integer, n::Integer, A::VecOrMatOrSparse, b::Vector{Float64}, c::Vector{Float64},
-        f::Integer, l::Integer, bu::Vector{Float64}, bl::Vector{Float64},
-        q::Vector{<:Integer}, s::Vector{<:Integer},
-        ep::Integer, ed::Integer, p::Vector{Float64},
-        primal_sol::Vector{Float64}=zeros(n),
-        dual_sol::Vector{Float64}=zeros(m),
-        slack::Vector{Float64}=zeros(m);
-        options...)
+    m::Integer,
+    n::Integer,
+    A::VecOrMatOrSparse,
+    P::VecOrMatOrSparse,
+    b::Vector{Float64},
+    c::Vector{Float64},
+    f::Integer,
+    l::Integer,
+    bu::Vector{Float64},
+    bl::Vector{Float64},
+    q::Vector{<:Integer},
+    s::Vector{<:Integer},
+    ep::Integer,
+    ed::Integer,
+    p::Vector{Float64},
+    primal_sol::Vector{Float64}=zeros(n),
+    dual_sol::Vector{Float64}=zeros(m),
+    slack::Vector{Float64}=zeros(m);
+    options...
+)
+
     T = scsint_t(linear_solver)
-    return SCS_solve(linear_solver, m, n, ManagedSCSMatrix{T}(m, n, A), b, c,
-                     f, l, bu, bl, q, s, ep, ed, p, primal_sol, dual_sol, slack; options...)
+    return SCS_solve(linear_solver, m, n,
+        ManagedSCSMatrix{T}(m, n, A),
+        ManagedSCSMatrix{T}(n, n, P),
+        b, c, f, l, bu, bl, q, s, ep, ed, p, primal_sol, dual_sol, slack; options...)
 end
 
+function SCS_solve(linear_solver::Type{<:LinearSolver},
+    m::Integer,
+    n::Integer,
+    A::ManagedSCSMatrix{T},
+    args...;
+    options...) where T
+    P = ManagedSCSMatrix{T}(n, n, spzeros(n,n))
+    return SCS_solve(linear_solver, m, n, A, P, args...; options...)
+end
+
+function SCS_solve(linear_solver::Type{<:LinearSolver},
+    m::Integer,
+    n::Integer,
+    A::AbstractMatrix,
+    args...;
+    options...) where T
+    mA = ManagedSCSMatrix{scsint_t(linear_solver)}(size(A)..., A)
+    return SCS_solve(linear_solver, m, n, mA, args...; options...)
+end
 
 # Wrappers for the direct C API.
 # Do not call these wrapper methods directly unless you understand the

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -1,5 +1,3 @@
-export SCS_init, SCS_solve, SCS_finish, SCS_version
-
 # SCS solves a problem of the form
 # minimize        c' * x
 # subject to      A * x + s = b

--- a/src/c_wrapper.jl
+++ b/src/c_wrapper.jl
@@ -72,12 +72,12 @@ function SCS_solve(linear_solver::Type{<:LinearSolver},
 
     data = SCSData(m, n, A, P, b, c, settings)
     # data holds pointers to objects which need to be protected from GC:
-    # A, b, c and settings
+    # A, P, b, c and settings
 
     cone = SCSCone{T}(f, l, bu, bl, q_T, s_T, ep, ed, p)
     info_ref = Base.cconvert(Ref{SCSInfo{T}}, SCSInfo{T}())
 
-    Base.GC.@preserve A P b c settings bu bl q_T s_T p begin
+    Base.GC.@preserve A P b c settings bu bl q_T s_T p options begin
         p_work = SCS_init(linear_solver, data, cone, info_ref)
         status = SCS_solve(linear_solver, p_work, data, cone, solution, info_ref)
         SCS_finish(linear_solver, p_work)

--- a/src/types.jl
+++ b/src/types.jl
@@ -292,8 +292,8 @@ end
 struct SCSCone{T<:SCSInt}
     f::T # number of linear equality constraints
     l::T # length of LP cone
-    bu::Ptr{Cdouble} # upper box values, length = bsize - 1
-    bl::Ptr{Cdouble} # lower box values, length = bsize - 1
+    bu::Ptr{Cdouble} # upper box values, length = bsize
+    bl::Ptr{Cdouble} # lower box values, length = bsize
     bsize::T # length of box cone constraint, including scale t
     q::Ptr{T} # array of second-order cone constraints
     qsize::T # length of SOC array

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -12,7 +12,7 @@ const CACHE = MOIU.UniversalFallback(MOIU.Model{Float64}())
 import SCS
 
 function moi_tests(T)
-    optimizer = SCS.Optimizer(linear_solver=T, eps=1e-6)
+    optimizer = SCS.Optimizer(linear_solver=T, eps_abs=1e-6, eps_rel=1e-7)
     MOI.set(optimizer, MOI.Silent(), true)
 
     @testset "SolverName" begin

--- a/test/MPB_wrapper.jl
+++ b/test/MPB_wrapper.jl
@@ -6,13 +6,13 @@ import MathProgBase
 for T in solvers
     @testset "MathProgBase $T" begin
         include(joinpath(dirname(dirname(pathof(MathProgBase))), "test", "conicinterface.jl"))
-        coniclineartest(SCS.SCSSolver(linear_solver=T, eps=1e-6, verbose=0),
+        coniclineartest(SCS.SCSSolver(linear_solver=T, eps_abs=1e-6, eps_rel=1e-6, verbose=0),
                         duals=true, tol=1e-5)
-        conicSOCtest(SCS.SCSSolver(linear_solver=T, eps=1e-6, verbose=0),
+        conicSOCtest(SCS.SCSSolver(linear_solver=T, eps_abs=1e-6, eps_rel=1e-6, verbose=0),
                      duals=true, tol=1e-5)
-        conicEXPtest(SCS.SCSSolver(linear_solver=T, eps=1e-6, verbose=0),
+        conicEXPtest(SCS.SCSSolver(linear_solver=T, eps_abs=1e-6, eps_rel=1e-7, verbose=0),
                      duals=true, tol=1e-5)
-        conicSDPtest(SCS.SCSSolver(linear_solver=T, eps=1e-6, verbose=0),
+        conicSDPtest(SCS.SCSSolver(linear_solver=T, eps_abs=1e-6, eps_rel=1e-7, verbose=0),
                      duals=true, tol=1e-5)
     end
 end

--- a/test/mpb_linear.jl
+++ b/test/mpb_linear.jl
@@ -11,7 +11,7 @@ using MathProgBase
 using LinearAlgebra
 using SparseArrays
 
-solver = SCSSolver()
+solver = SCSSolver(eps_abs=1e-5, eps_rel=1e-5)
 objtol = 1e-4
 primaltol = 1e-4
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -9,79 +9,82 @@
 
 using MathProgBase
 
-# The normal test
-A = [1.0 1.0 0.0 0.0 0.0;
-     0.0 1.0 0.0 0.0 1.0;
-     0.0 0.0 1.0 1.0 1.0]
-collb = [0.0, 0.0, 0.0, 0.0, 0.0]
-obj   = [3.0, 4.0, 4.0, 9.0, 5.0]
-rowub = [ 5.0,  3.0,  9.0]
-s = SCSSolver()
-m = MathProgBase.ConicModel(s)
-MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
-MathProgBase.optimize!(m)
-
-@test isapprox(MathProgBase.getobjval(m), -99.0, rtol=1e-9)
-@test !isapprox(MathProgBase.getobjval(m), -99.0, rtol=1e-10)
-# we test above to check if the next optimize actually does something
-
-# With eps = 1e-14, solution should be far more accurate
-s = SCSSolver(eps=1e-14)
-m = MathProgBase.ConicModel(s)
-MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
-MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, rtol=1e-14)
-
-# With a warmstart from the eps = 1e-14 solution, solution should be extremely accurate even after 1 iteration
-SCS.addoption!(m, :warm_start, true)
-SCS.addoption!(m, :max_iters, 1)
-MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, rtol=1e-14)
-
-# Now let's do the same warmstart, but on a new instance of the same problem
-primal_sol = m.primal_sol
-dual_sol = m.dual_sol
-slack = m.slack
-s = SCSSolver(max_iters=1)
-m = MathProgBase.ConicModel(s)
-MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
-MathProgBase.setwarmstart!(m, primal_sol; dual_sol = dual_sol, slack = slack)
-MathProgBase.optimize!(m)
-@test isapprox(MathProgBase.getobjval(m), -99.0, rtol=1e-14)
-
-# tests for incorrect options
-s = SCSSolver(eps=1e-12, epps=1.0)
-m = MathProgBase.ConicModel(s)
-MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
-
-@test_throws ArgumentError MathProgBase.optimize!(m)
-
-err = try
+@testset "SCS options" begin
+    # The normal test
+    A = [1.0 1.0 0.0 0.0 0.0;
+        0.0 1.0 0.0 0.0 1.0;
+        0.0 0.0 1.0 1.0 1.0]
+    collb = [0.0, 0.0, 0.0, 0.0, 0.0]
+    obj   = [3.0, 4.0, 4.0, 9.0, 5.0]
+    rowub = [ 5.0,  3.0,  9.0]
+    s = SCSSolver(eps_abs=1e-6, eps_rel=1e-7)
+    m = MathProgBase.ConicModel(s)
+    MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
     MathProgBase.optimize!(m)
-catch ex
-    ex
-end
-@test err.msg == "Unrecognized option passed to SCS: epps;
-Recognized options are: linear_solver, normalize, scale, rho_x, max_iters, eps, alpha, cg_rate, verbose, warm_start, acceleration_lookback and write_data_filename."
 
-# tests for incorrect options
-s = SCSSolver(linear_solver="AAA", eps=1e-12, epps=1.0)
-m = MathProgBase.ConicModel(s)
-MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
+    @test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-5, rtol=0.0)
+    @test !isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-6, rtol=0.0)
 
-@test_throws ArgumentError MathProgBase.optimize!(m)
-
-err = try
+    # With eps = 1e-10, solution should be far more accurate
+    s = SCSSolver(eps_abs=1e-10, eps_rel=1e-12, acceleration_lookback=0)
+    m = MathProgBase.ConicModel(s)
+    MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
     MathProgBase.optimize!(m)
-catch ex
-    ex
-end
+    @test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-9, rtol=0.0)
+    @test !isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)
 
-let msg = "Unrecognized linear_solver passed to SCS: AAA;\nRecognized options are: "
-    if isdefined(SCS, :gpuindirect)
-        msg *= "SCS.DirectSolver, SCS.IndirectSolver and SCS.GpuIndirectSolver."
-    else
-        msg *= "SCS.DirectSolver and SCS.IndirectSolver."
+    # With a warmstart from the eps = 1e-10 solution, solution should be extremely accurate even after 1 iteration
+    SCS.addoption!(m, :warm_start, true)
+    SCS.addoption!(m, :max_iters, 151) #!!!! below 151 it gets Nan
+    MathProgBase.optimize!(m)
+    @test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-9, rtol=0.0)
+    @test !isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)
+
+    # Now let's do the same warmstart, but on a new instance of the same problem
+    primal_sol = m.primal_sol
+    dual_sol = m.dual_sol
+    slack = m.slack
+    s = SCSSolver(max_iters=1)
+    m = MathProgBase.ConicModel(s)
+    MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
+    MathProgBase.setwarmstart!(m, primal_sol; dual_sol = dual_sol, slack = slack)
+    MathProgBase.optimize!(m)
+    @test isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-9, rtol=0.0)
+    @test !isapprox(MathProgBase.getobjval(m), -99.0, atol=1e-10, rtol=0.0)
+
+    # tests for incorrect options
+    s = SCSSolver(eps_abs=1e-12, epps=1.0)
+    m = MathProgBase.ConicModel(s)
+    MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
+
+    @test_throws ArgumentError MathProgBase.optimize!(m)
+
+    err = try
+        MathProgBase.optimize!(m)
+    catch ex
+        ex
     end
-    @test err.msg == msg
+    @test err.msg == """Unrecognized option passed to SCS: epps;\nRecognized options are: linear_solver, normalize, scale, rho_x, max_iters, eps_abs, eps_rel, eps_infeas, alpha, time_limit_secs, verbose, warm_start, acceleration_lookback, acceleration_interval, adaptive_scaling, write_data_filename and log_csv_filename."""
+
+    # tests for incorrect options
+    s = SCSSolver(linear_solver="AAA", eps_abs=1e-12, epps=1.0)
+    m = MathProgBase.ConicModel(s)
+    MathProgBase.loadproblem!(m, -obj, A, rowub, [(:NonNeg,1:3)],[(:NonNeg,1:5)])
+
+    @test_throws ArgumentError MathProgBase.optimize!(m)
+
+    err = try
+        MathProgBase.optimize!(m)
+    catch ex
+        ex
+    end
+
+    let msg = "Unrecognized linear_solver passed to SCS: AAA;\nRecognized options are: "
+        if isdefined(SCS, :gpuindirect)
+            msg *= "SCS.DirectSolver, SCS.IndirectSolver and SCS.GpuIndirectSolver."
+        else
+            msg *= "SCS.DirectSolver and SCS.IndirectSolver."
+        end
+        @test err.msg == msg
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,13 +13,15 @@ solvers = SCS.available_solvers
 include("test_problems.jl")
 include("MOI_wrapper.jl")
 
-for s in solvers
-    feasible_basic_problems(s)
-end
-include("options.jl")
-include("MPB_wrapper.jl")
+@testset "SCS" begin
+    @testset "Basic feasible problems: $s" for s in solvers
+        feasible_basic_problems(s)
+    end
 
-for s in solvers
-    moi_tests(s)
-end
+    include("options.jl")
+    include("MPB_wrapper.jl")
 
+    @testset "MOI wrapper: $s" for s in solvers
+        moi_tests(s)
+    end
+end

--- a/test/test_problems.jl
+++ b/test/test_problems.jl
@@ -431,7 +431,7 @@ function feasible_basic_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
+    sol = SCS.SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
     @test sol.ret_val == 1
     @test SCS.raw_status(sol.info) == "solved"
 end
@@ -557,7 +557,7 @@ function feasible_exponential_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
+    sol = SCS.SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
     @test sol.ret_val == 1
     @test SCS.raw_status(sol.info) == "solved"
 end
@@ -636,7 +636,7 @@ function feasible_sdp_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
+    sol = SCS.SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
     @test sol.ret_val == 1
     @test SCS.raw_status(sol.info) == "solved"
 end
@@ -689,14 +689,14 @@ function feasible_pow_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, p, max_iters=1000)
+    sol = SCS.SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, p, max_iters=1000)
     @test sol.ret_val == 1
     @test SCS.raw_status(sol.info) == "solved"
 end
 
 function feasible_basic_problems(solver)
     A = reshape([1.0],(1,1))
-    solution = SCS_solve(solver, 1, 1, A, [1.0], [1.0], 1, 0, Float64[], Float64[], Int[], Int[], 0, 0, Float64[]);
+    solution = SCS.SCS_solve(solver, 1, 1, A, [1.0], [1.0], 1, 0, Float64[], Float64[], Int[], Int[], 0, 0, Float64[]);
     @test solution.ret_val == 1
 
     feasible_basic_conic(solver)

--- a/test/test_problems.jl
+++ b/test/test_problems.jl
@@ -8,6 +8,8 @@ function feasible_basic_conic(T)
 
     f = 0
     l = 100
+    bu = Float64[]
+    bl = Float64[]
     ep = 0
     ed = 0
     q = [12]
@@ -429,9 +431,9 @@ function feasible_basic_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, q, s, ep, ed, Float64[])
+    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
     @test sol.ret_val == 1
-    @test SCS.raw_status(sol.info) == "Solved"
+    @test SCS.raw_status(sol.info) == "solved"
 end
 
 # Feasible conic problem with exponential cones (no SDP cones)
@@ -441,6 +443,8 @@ function feasible_exponential_conic(T)
     m = 71
     f = 10
     l = 10
+    bu = Float64[]
+    bl = Float64[]
     ep = 10
     ed = 5
     q = [0,1,0,2,3]
@@ -553,9 +557,9 @@ function feasible_exponential_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, q, s, ep, ed, Float64[])
-    @assert sol.ret_val == 1
-    @test SCS.raw_status(sol.info) == "Solved"
+    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
+    @test sol.ret_val == 1
+    @test SCS.raw_status(sol.info) == "solved"
 end
 
 # Feasible conic problem with exponential and SDP cones
@@ -566,6 +570,8 @@ function feasible_sdp_conic(T)
     m = 46
     f = 3
     l = 3
+    bu = Float64[]
+    bl = Float64[]
     ep = 2
     ed = 2
     q = [2,3,4]
@@ -630,9 +636,9 @@ function feasible_sdp_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, q, s, ep, ed, Float64[])
+    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, Float64[], max_iters=1000)
     @test sol.ret_val == 1
-    @test SCS.raw_status(sol.info) == "Solved"
+    @test SCS.raw_status(sol.info) == "solved"
 end
 
 # Feasible conic problem with power cones
@@ -641,6 +647,8 @@ function feasible_pow_conic(T)
     m = 28
     f = 5
     l = 5
+    bu = Float64[]
+    bl = Float64[]
     ep = 0
     ed = 0
     q = Int[]
@@ -681,14 +689,14 @@ function feasible_pow_conic(T)
 
     A = SparseMatrixCSC(m, n, colptr .+ 1, rowval .+ 1, vec(values))
 
-    sol = SCS_solve(T, m, n, A, b, c, f, l, q, s, ep, ed, p)
+    sol = SCS_solve(T, m, n, A, b, c, f, l, bu, bl, q, s, ep, ed, p, max_iters=1000)
     @test sol.ret_val == 1
-    @test SCS.raw_status(sol.info) == "Solved"
+    @test SCS.raw_status(sol.info) == "solved"
 end
 
 function feasible_basic_problems(solver)
     A = reshape([1.0],(1,1))
-    solution = SCS_solve(solver, 1, 1, A, [1.0], [1.0], 1, 0, Int[], Int[], 0, 0, Float64[]);
+    solution = SCS_solve(solver, 1, 1, A, [1.0], [1.0], 1, 0, Float64[], Float64[], Int[], Int[], 0, 0, Float64[]);
     @test solution.ret_val == 1
 
     feasible_basic_conic(solver)


### PR DESCRIPTION
a few problems:

* when warmstarting, setting `p,d,s` works just fine, but unless a number of iterations is allowed (`151` in the default settings) objective becomes `nan` (already in scs). This may explain some of the test errors; This seems to be a problem with `scs` itself @bodono 
* `feasible_exponential_conic(...)` and `feasible_sdp_conic(...)` from `test/test_problems.jl` fail with numerous warnings `warning: exp cone newton step hit maximum 100 iters`. This is probably an issue with current branch; I'll investigate.

In general this reaches test status
```julia
Test Summary:                                             | Pass  Fail  Total
SCS                                                       | 5240    74   5314
```
with `4` `feasible_*` failures and the same `33` failures for each of `SCS.DirectSolver` and `SCS.IndirectSolver`:
```julia
  MOI wrapper: SCS.DirectSolver                           | 2390    33   2423
    SolverName                                            |    1            1
    Unit                                                  |  348          348
    Continuous linear problems with SCS.DirectSolver      |  478    18    496
      linear8a                                            |   13           13
      linear14                                            |   40           40
      linear6                                             |   34           34
      linear4                                             |   24           24
      linear3                                             |   28           28
      linear9                                             |   13     2     15
      linear8c                                            |   13           13
      linear1                                             |  120          120
      linear2                                             |   24           24
      partial_start                                       |    1     5      6
      linear12                                            |   17           17
      linear7                                             |   22           22
      linear8b                                            |   12           12
      linear10b                                           |   18           18
      linear10                                            |   27    11     38
      linear15                                            |   12           12
      linear5                                             |   28           28
      linear13                                            |   16           16
      linear11                                            |   16           16
    ADMMIterations attribute with SCS.DirectSolver        |  121          121
    Continuous quadratic problems with SCS.DirectSolver   |   87     8     95
      qcp1                                                |   12     8     20
      qcp3                                                |   17           17
      qcp4                                                |   21           21
      qcp5                                                |   21           21
      qcp2                                                |   16           16
    Continuous conic problems with SCS.DirectSolver       | 1355     7   1362
      norminf                                             |   89           89
      normone                                             |   88           88
      sdp                                                 |  237          237
      normnuc                                             |   30           30
      dualexp                                             |   50           50
      dualpow                                             |   48           48
      exp                                                 |   97           97
      lin                                                 |  135          135
      logdet                                              |   72           72
      soc                                                 |  131          131
      normspec                                            |   30           30
      rootdet                                             |   54     7     61
        rootdett                                          |   54     7     61
          rootdett1v                                      |   23           23
          rootdett1f                                      |   23           23
          rootdett2                                       |    8     7     15
      relentr                                             |   15           15
      rsoc                                                |  129          129
      pow                                                 |   42           42
      geomean                                             |  108          108
``` 