### PR TITLE
Fix VectorOfVariables-in-PositiveSemidefiniteConeTriangle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCS"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 repo = "https://github.com/jump-dev/SCS.jl"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -86,6 +86,29 @@ function test_RawOptimizerAttribute()
     @test MOI.get(model, MOI.RawOptimizerAttribute("eps")) == 2.0
 end
 
+function test_constrained_variables()
+    model = MOI.Bridges.full_bridge_optimizer(
+        MOI.Utilities.CachingOptimizer(
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+            SCS.Optimizer(),
+        ),
+        Float64,
+    )
+    @test MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    x = MOI.add_variables(model, 6)
+    f = MOI.VectorOfVariables(x)
+    s = MOI.PositiveSemidefiniteConeTriangle(3)
+    @test isa(
+        MOI.add_constraint(model, f, s),
+        MOI.ConstraintIndex{typeof(f),typeof(s)},
+    )
+    return
+end
+
 end  # module
 
 TestSCS.runtests()


### PR DESCRIPTION
Closes #224 

The `SetMap` bridges are set up in MOI such that the bridge should accept any incoming function type. That means that this wasn't getting `functionized` in between.

I looked at changing things on the MOI end, but it was easier to just add support here.