### PR TITLE
Fix objective values for certificates

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -286,6 +286,14 @@ function MOI.optimize!(
         dest.sol.slack;
         options...,
     )
+    # If the solution is an infeasibility certificate, the objective values are
+    # left as infinite, not the value corresponding to the ray.
+    if !isfinite(sol.info.dobj)
+        sol.info.dobj = -Ab.constants' * sol.y
+    end
+    if !isfinite(sol.info.pobj)
+        sol.info.pobj = c' * sol.x
+    end
     dest.sol = MOISolution(
         sol.x,
         sol.y,


### PR DESCRIPTION
Updated for https://github.com/jump-dev/MathOptInterface.jl/pull/1660

<s>Tests will fail because of https://github.com/jump-dev/MathOptInterface.jl/pull/1656#issuecomment-972125589</s> Only on `master`, not 0.10.5.

Opened upstream: https://github.com/cvxgrp/scs/issues/185