### PR TITLE
Set library path in __init__

### DIFF
--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -4,15 +4,14 @@ import Requires
 import SCS_jll
 import SparseArrays
 
-const indirect = SCS_jll.libscsindir
-const direct = SCS_jll.libscsdir
-
 function __init__()
+    global indirect = SCS_jll.libscsindir
+    global direct = SCS_jll.libscsdir
     Requires.@require(
         CUDA_jll = "e9e359dc-d701-5aa8-82ae-09bbf812ea83",
         begin
             import SCS_GPU_jll
-            const gpuindirect = SCS_GPU_jll.libscsgpuindir
+            global gpuindirect = SCS_GPU_jll.libscsgpuindir
             push!(available_solvers, GpuIndirectSolver)
         end
     )


### PR DESCRIPTION
See https://github.com/jump-dev/ECOS.jl/pull/134

There's no performance penalty to using `global` because they are only evaluated in the ccall once.