### PR TITLE
Fix SCS_jll@v3.0.0 to avoid breaking v3.2.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 MathOptInterface = "1"
 Requires = "1"
 SCS_GPU_jll = "=3.0.0, =3.0.1"
-SCS_jll = "=3.0.0"
+SCS_jll = "=3.0.0, =3.0.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCS"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 repo = "https://github.com/jump-dev/SCS.jl"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 MathOptInterface = "1"
 Requires = "1"
 SCS_GPU_jll = "=3.0.0, =3.0.1"
-SCS_jll = "3.0.0"
+SCS_jll = "=3.0.0"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
SCS_jll@v3.2.0 is a breaking release so it's causing a segfault in the JuMP documentation: https://github.com/jump-dev/JuMP.jl/pull/2900