### PR TITLE
add support for sparse-direct-mkl-pardiso solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCS"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 repo = "https://github.com/jump-dev/SCS.jl"
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ repo = "https://github.com/jump-dev/SCS.jl"
 version = "1.1.1"
 
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SCS_GPU_jll = "af6e375f-46ec-5fa0-b791-491b0dfa44a4"
+SCS_MKL_jll = "3f2553a9-4106-52be-b7dd-865123654657"
 SCS_jll = "f4f2fc5b-1d94-523c-97ea-2ab488bedf4b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -14,6 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 MathOptInterface = "1"
 Requires = "1"
 SCS_GPU_jll = "=3.2.0"
+SCS_MKL_jll = "=3.2.1"
 SCS_jll = "=3.2.0"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCS"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 repo = "https://github.com/jump-dev/SCS.jl"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ repo = "https://github.com/jump-dev/SCS.jl"
 version = "1.1.2"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SCS_GPU_jll = "af6e375f-46ec-5fa0-b791-491b0dfa44a4"

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 MathOptInterface = "1"
 Requires = "1"
 SCS_GPU_jll = "=3.2.0"
-SCS_MKL_jll = "=3.2.1"
-SCS_jll = "=3.2.0"
+SCS_MKL_jll = "=3.2.2"
+SCS_jll = "=3.2.1"
 julia = "1.6"
 
 [extras]

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -25,7 +25,7 @@ function __init__()
     Requires.@require(
         MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7",
         begin
-            if Sys.islinux()
+            if Sys.islinux() && Sys.ARCH == :x86_64
                 import SCS_MKL_jll
                 import SCS_MKL_jll.MKL_jll
                 global mkldirect = SCS_MKL_jll.libscsmkl

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -3,11 +3,25 @@ module SCS
 import MathOptInterface
 import Requires
 import SCS_jll
+import SCS_MKL_jll
+import SCS_MKL_jll.MKL_jll
+import Libdl
 import SparseArrays
 
 function __init__()
     global indirect = SCS_jll.libscsindir
     global direct = SCS_jll.libscsdir
+    global mkldirect = SCS_MKL_jll.libscsmkl
+
+    MKLROOT = joinpath(MKL_jll.artifact_dir, "lib")
+    # dlopen with RTLD_GLOBAL to avoid undefined symbols when dlopening
+    # `lib_mkl_gnu_thread.so`
+    Libdl.dlopen(
+        joinpath(MKLROOT, "libmkl_core.so"),
+        Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL,
+    )
+    Libdl.dlopen(joinpath(MKLROOT, "libmkl_gnu_thread.so"))
+
     Requires.@require(
         CUDA_jll = "e9e359dc-d701-5aa8-82ae-09bbf812ea83",
         begin
@@ -23,9 +37,10 @@ include("c_wrapper.jl")
 include("linear_solvers/direct.jl")
 include("linear_solvers/indirect.jl")
 include("linear_solvers/gpu_indirect.jl")
+include("linear_solvers/mkl_direct.jl")
 include("MOI_wrapper/MOI_wrapper.jl")
 
-const available_solvers = [DirectSolver, IndirectSolver]
+const available_solvers = [DirectSolver, MKLDirectSolver, IndirectSolver]
 
 export scs_solve
 

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -20,11 +20,13 @@ function __init__()
     Requires.@require(
         MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7",
         begin
-            import SCS_MKL_jll
-            import SCS_MKL_jll.MKL_jll
-            global mkldirect = SCS_MKL_jll.libscsmkl
+            if Sys.islinux()
+                import SCS_MKL_jll
+                import SCS_MKL_jll.MKL_jll
+                global mkldirect = SCS_MKL_jll.libscsmkl
 
-            push!(available_solvers, MKLDirectSolver)
+                push!(available_solvers, MKLDirectSolver)
+            end
         end
     )
     return

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -3,24 +3,11 @@ module SCS
 import MathOptInterface
 import Requires
 import SCS_jll
-import SCS_MKL_jll
-import SCS_MKL_jll.MKL_jll
-import Libdl
 import SparseArrays
 
 function __init__()
     global indirect = SCS_jll.libscsindir
     global direct = SCS_jll.libscsdir
-    global mkldirect = SCS_MKL_jll.libscsmkl
-
-    MKLROOT = joinpath(MKL_jll.artifact_dir, "lib")
-    # dlopen with RTLD_GLOBAL to avoid undefined symbols when dlopening
-    # `lib_mkl_gnu_thread.so`
-    Libdl.dlopen(
-        joinpath(MKLROOT, "libmkl_core.so"),
-        Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL,
-    )
-    Libdl.dlopen(joinpath(MKLROOT, "libmkl_gnu_thread.so"))
 
     Requires.@require(
         CUDA_jll = "e9e359dc-d701-5aa8-82ae-09bbf812ea83",
@@ -28,6 +15,26 @@ function __init__()
             import SCS_GPU_jll
             global gpuindirect = SCS_GPU_jll.libscsgpuindir
             push!(available_solvers, GpuIndirectSolver)
+        end
+    )
+    Requires.@require(
+        MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7",
+        begin
+            import SCS_MKL_jll
+            import SCS_MKL_jll.MKL_jll
+            import Libdl
+            global mkldirect = SCS_MKL_jll.libscsmkl
+
+            MKLROOT = joinpath(MKL_jll.artifact_dir, "lib")
+            # dlopen with RTLD_GLOBAL to avoid undefined symbols when dlopening
+            # `lib_mkl_gnu_thread.so`
+            Libdl.dlopen(
+                joinpath(MKLROOT, "libmkl_core.so"),
+                Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL,
+            )
+            Libdl.dlopen(joinpath(MKLROOT, "libmkl_gnu_thread.so"))
+
+            push!(available_solvers, MKLDirectSolver)
         end
     )
     return
@@ -40,7 +47,7 @@ include("linear_solvers/gpu_indirect.jl")
 include("linear_solvers/mkl_direct.jl")
 include("MOI_wrapper/MOI_wrapper.jl")
 
-const available_solvers = [DirectSolver, MKLDirectSolver, IndirectSolver]
+const available_solvers = [DirectSolver, IndirectSolver]
 
 export scs_solve
 

--- a/src/SCS.jl
+++ b/src/SCS.jl
@@ -22,17 +22,7 @@ function __init__()
         begin
             import SCS_MKL_jll
             import SCS_MKL_jll.MKL_jll
-            import Libdl
             global mkldirect = SCS_MKL_jll.libscsmkl
-
-            MKLROOT = joinpath(MKL_jll.artifact_dir, "lib")
-            # dlopen with RTLD_GLOBAL to avoid undefined symbols when dlopening
-            # `lib_mkl_gnu_thread.so`
-            Libdl.dlopen(
-                joinpath(MKLROOT, "libmkl_core.so"),
-                Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL,
-            )
-            Libdl.dlopen(joinpath(MKLROOT, "libmkl_gnu_thread.so"))
 
             push!(available_solvers, MKLDirectSolver)
         end

--- a/src/linear_solvers/direct.jl
+++ b/src/linear_solvers/direct.jl
@@ -56,6 +56,8 @@ function scs_finish(::Type{DirectSolver}, work::Ptr{Cvoid})
     return @ccall direct.scs_finish(work::Ptr{Cvoid})::Cvoid
 end
 
-function scs_version()
+function scs_version(::Type{DirectSolver})
     return unsafe_string(@ccall direct.scs_version()::Cstring)
 end
+
+scs_version() = scs_version(DirectSolver)

--- a/src/linear_solvers/gpu_indirect.jl
+++ b/src/linear_solvers/gpu_indirect.jl
@@ -55,3 +55,7 @@ end
 function scs_finish(::Type{GpuIndirectSolver}, work::Ptr{Cvoid})
     return @ccall gpuindirect.scs_finish(work::Ptr{Cvoid})::Cvoid
 end
+
+function scs_version(::Type{GpuIndirectSolver})
+    return unsafe_string(@ccall gpuindirect.scs_version()::Cstring)
+end

--- a/src/linear_solvers/indirect.jl
+++ b/src/linear_solvers/indirect.jl
@@ -55,3 +55,7 @@ end
 function scs_finish(::Type{IndirectSolver}, work::Ptr{Cvoid})
     return @ccall indirect.scs_finish(work::Ptr{Cvoid})::Cvoid
 end
+
+function scs_version(::Type{IndirectSolver})
+    return unsafe_string(@ccall indirect.scs_version()::Cstring)
+end

--- a/src/linear_solvers/mkl_direct.jl
+++ b/src/linear_solvers/mkl_direct.jl
@@ -1,0 +1,61 @@
+struct MKLDirectSolver <: LinearSolver end
+
+scsint_t(::Type{MKLDirectSolver}) = Clonglong
+
+function scs_set_default_settings(
+    ::Type{MKLDirectSolver},
+    stgs::ScsSettings{I},
+) where {I<:Clonglong}
+    return @ccall(
+        mkldirect.scs_set_default_settings(stgs::Ref{ScsSettings{I}})::Cvoid,
+    )
+end
+
+function scs_init(
+    ::Type{MKLDirectSolver},
+    data::ScsData{I},
+    cone::ScsCone{I},
+    stgs::ScsSettings{I},
+) where {I<:Clonglong}
+    return @ccall mkldirect.scs_init(
+        data::Ref{ScsData{I}},
+        cone::Ref{ScsCone{I}},
+        stgs::Ref{ScsSettings{I}},
+    )::Ptr{Cvoid}
+end
+
+function scs_update(
+    ::Type{MKLDirectSolver},
+    work::Ptr{Cvoid},
+    b::Vector{Float64},
+    c::Vector{Float64},
+)
+    return @ccall mkldirect.scs_update(
+        work::Ptr{Cvoid},
+        b::Ref{Float64},
+        c::Ref{Float64},
+    )::Clonglong
+end
+
+function scs_solve(
+    ::Type{MKLDirectSolver},
+    work::Ptr{Cvoid},
+    solution::ScsSolution,
+    info::ScsInfo{I},
+    warm_start::Integer,
+) where {I<:Clonglong}
+    return @ccall mkldirect.scs_solve(
+        work::Ptr{Cvoid},
+        solution::Ref{ScsSolution},
+        info::Ref{ScsInfo{I}},
+        warm_start::Clonglong,
+    )::Clonglong
+end
+
+function scs_finish(::Type{MKLDirectSolver}, work::Ptr{Cvoid})
+    return @ccall mkldirect.scs_finish(work::Ptr{Cvoid})::Cvoid
+end
+
+function scs_version(::Type{MKLDirectSolver})
+    return unsafe_string(@ccall mkldirect.scs_version()::Cstring)
+end

--- a/src/linear_solvers/mkl_direct.jl
+++ b/src/linear_solvers/mkl_direct.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2022: SCS.jl contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 struct MKLDirectSolver <: LinearSolver end
 
 scsint_t(::Type{MKLDirectSolver}) = Clonglong

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -21,7 +21,9 @@ test_DirectSolver() = _test_runtests(SCS.DirectSolver)
 
 test_IndirectSolver() = _test_runtests(SCS.IndirectSolver)
 
-test_MKLDirectSolver() = _test_runtests(SCS.MKLDirectSolver)
+@static if Sys.islinux()
+    test_MKLDirectSolver() = _test_runtests(SCS.MKLDirectSolver)
+end
 
 function _test_runtests(linear_solver)
     optimizer = SCS.Optimizer()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -21,6 +21,8 @@ test_DirectSolver() = _test_runtests(SCS.DirectSolver)
 
 test_IndirectSolver() = _test_runtests(SCS.IndirectSolver)
 
+test_MKLDirectSolver() = _test_runtests(SCS.MKLDirectSolver)
+
 function _test_runtests(linear_solver)
     optimizer = SCS.Optimizer()
     MOI.set(

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -26,7 +26,7 @@ test_DirectSolver() = _test_runtests(SCS.DirectSolver)
 
 test_IndirectSolver() = _test_runtests(SCS.IndirectSolver)
 
-@static if Sys.islinux()
+@static if Sys.islinux() && Sys.ARCH == :x86_64
     test_MKLDirectSolver() = _test_runtests(SCS.MKLDirectSolver)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ Pkg.add(Pkg.PackageSpec(name = "MKL_jll", version = "2022"))
 using MKL_jll  # MKL_jll must be loaded _before_ SCS!
 using SCS
 
-if Sys.islinux()
+if Sys.islinux() && Sys.ARCH == :x86_64
     @test SCS.MKLDirectSolver in SCS.available_solvers
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,11 +6,17 @@ if get(ENV, "BUILDKITE", "false") == "true"
 end
 
 using Test
+# MKL_jll is not in our Project.toml, so we need to install it.
+import Pkg
+Pkg.add(Pkg.PackageSpec(name = "MKL_jll", version = "2022"))
+using MKL_jll  # MKL_jll must be loaded _before_ SCS!
 using SCS
+
+@test SCS.MKLDirectSolver in SCS.available_solvers
 
 include("test_problems.jl")
 @test SCS.scs_version() isa String
-@test VersionNumber() >= v"3.2.0"
+@test VersionNumber(SCS.scs_version()) >= v"3.2.0"
 for solver in SCS.available_solvers
     @test SCS.scs_version(solver) isa String
     @test VersionNumber(SCS.scs_version(solver)) >= v"3.2.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,9 @@ Pkg.add(Pkg.PackageSpec(name = "MKL_jll", version = "2022"))
 using MKL_jll  # MKL_jll must be loaded _before_ SCS!
 using SCS
 
-@test SCS.MKLDirectSolver in SCS.available_solvers
+if Sys.islinux()
+    @test SCS.MKLDirectSolver in SCS.available_solvers
+end
 
 include("test_problems.jl")
 @test SCS.scs_version() isa String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,14 @@ using Test
 using SCS
 
 include("test_problems.jl")
-for s in SCS.available_solvers
-    feasible_basic_problems(s)
-    test_options(s)
+@test SCS.scs_version() isa String
+@test VersionNumber() >= v"3.2.0"
+for solver in SCS.available_solvers
+    @test SCS.scs_version(solver) isa String
+    @test VersionNumber(SCS.scs_version(solver)) >= v"3.2.0"
+
+    feasible_basic_problems(solver)
+    test_options(solver)
 end
 
 include("MOI_wrapper.jl")


### PR DESCRIPTION
this is a proof of concept, depends on https://github.com/JuliaPackaging/Yggdrasil/pull/4773 but works locally ;)

Besides `MKLDirectSolver` I've added runtime `scs_version` for each solver library; 
@odow technically it's a breaking change (there is argumentless version anymore), but it was just internal function that we didn't even test. So maybe we should ask do we actually need to query for version at runtime?  
