### PR TITLE
Prep for v1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCS"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 repo = "https://github.com/jump-dev/SCS.jl"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
I'm going to declare https://github.com/jump-dev/SCS.jl/pull/270 as a bug fix, because the previous bridge was actually incorrect and falsely allowed support for VectorNonlinearFunction.

x-ref https://github.com/jump-dev/MathOptInterface.jl/pull/2201

I didn't realize that this PR was unreleased, so it took me quiiiite a long time to figure out when reading the code.