### PR TITLE
Add compat to stdlibs in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,13 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 MathOptInterface = "1.20"
+Pkg = "<0.0.1, ^1.6"
 Requires = "1"
 SCS_GPU_jll = "=3.2.3"
 SCS_MKL_jll = "=3.2.2, =3.2.3"
 SCS_jll = "=3.2.1, =3.2.3"
+SparseArrays = "<0.0.1, ^1.6"
+Test = "<0.0.1, ^1.6"
 julia = "1.6"
 
 [extras]
@@ -24,4 +27,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Pkg"]
+test = ["Pkg", "Test"]


### PR DESCRIPTION
We need the <0.0.1 for compatibility with versions of Julia that do not allow upgradable stdlibs.

x-ref https://github.com/JuliaTesting/Aqua.jl/pull/224