### PR TITLE
Fix return type of ListOfNonstandardBridges

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -132,7 +132,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 end
 
 function MOI.get(::Optimizer, ::MOI.Bridges.ListOfNonstandardBridges)
-    return [ScaledPSDConeBridge{Cdouble}]
+    return Type[ScaledPSDConeBridge{Cdouble}]
 end
 
 MOI.get(::Optimizer, ::MOI.SolverName) = "SCS"


### PR DESCRIPTION
This is now checked
https://github.com/jump-dev/MathOptInterface.jl/pull/2665
so SCS does not even precompile
```julia
ERROR: LoadError: TypeError: in typeassert, expected Vector{Type}, got a value of type Vector{UnionAll}
Stacktrace:
  [1] get(model::MathOptInterface.Utilities.CachingOptimizer{SCS.Optimizer, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, attr::MathOptInterface.Bridges.ListOfNonstandardBridges{Float64})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/yI6C0/src/Utilities/cachingoptimizer.jl:1047
  [2] full_bridge_optimizer(model::MathOptInterface.Utilities.CachingOptimizer{SCS.Optimizer, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, ::Type{Float64})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/yI6C0/src/Bridges/Bridges.jl:58
  [3] instantiate(optimizer_constructor::Any; with_bridge_type::Type{Float64}, with_cache_type::Nothing)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/yI6C0/src/instantiate.jl:190
  [4] macro expansion
    @ ~/.julia/dev/SCS/src/SCS.jl:33 [inlined]
  [5] macro expansion
    @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:78 [inlined]
```