### PR TITLE
Improve code coverage

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -63,10 +63,6 @@ function MOI.Utilities.load_constants(
     return
 end
 
-function MOI.Utilities.function_constants(x::_SetConstants, rows)
-    return MOI.Utilities.function_constants(x.b, rows)
-end
-
 function MOI.Utilities.set_from_constants(x::_SetConstants, S, rows)
     return MOI.Utilities.set_from_constants(x.b, S, rows)
 end

--- a/src/MOI_wrapper/sets/ComplexPositiveSemidefiniteConeTriangle.jl
+++ b/src/MOI_wrapper/sets/ComplexPositiveSemidefiniteConeTriangle.jl
@@ -31,28 +31,6 @@ function MOI.dimension(x::ComplexPositiveSemidefiniteConeTriangle)
 end
 
 function MOI.Utilities.set_dot(
-    x::AbstractVector{S},
-    y::AbstractVector{T},
-    set::ComplexPositiveSemidefiniteConeTriangle,
-) where {S,T}
-    U = promote_type(S, T)
-    result = zero(U)
-    d = set.side_dimension
-    k = 0
-    for j in 1:d
-        for i in 1:j-1
-            k += 1
-            result += 2 * x[k] * y[k]
-            k += 1
-            result += 2 * x[k] * y[k]
-        end
-        k += 1
-        result += x[k] * y[k]
-    end
-    return result
-end
-
-function MOI.Utilities.set_dot(
     x::MOI.Utilities.CanonicalVector{T},
     y::MOI.Utilities.CanonicalVector{T},
     set::ComplexPositiveSemidefiniteConeTriangle,
@@ -66,28 +44,7 @@ function MOI.Utilities.set_dot(
     end
 end
 
-function MOI.Utilities.dot_coefficients(
-    a::AbstractVector,
-    set::ComplexPositiveSemidefiniteConeTriangle,
-)
-    d = set.side_dimension
-    b = copy(a)
-    k = 0
-    for j in 1:d
-        for i in 1:j-1
-            k += 1
-            b[k] /= 2
-            k += 1
-            b[k] /= 2
-        end
-        k += 1
-    end
-    return b
-end
-
-function MOI.is_set_dot_scaled(::Type{ComplexPositiveSemidefiniteConeTriangle})
-    return true
-end
+MOI.is_set_dot_scaled(::Type{ComplexPositiveSemidefiniteConeTriangle}) = true
 
 struct HermitianComplexPSDConeBridge{T,F} <:
        MOI.Bridges.Constraint.SetMapBridge{

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -523,6 +523,32 @@ function test_NormNuclearConeBridge()
     return
 end
 
+function test_HermitianComplexPSDConeBridge()
+    MOI.Bridges.runtests(
+        SCS.HermitianComplexPSDConeBridge,
+        """
+        variables: x1, x2, x3, x4
+        [x1, x2, x3, x4] in MOI.HermitianPositiveSemidefiniteConeTriangle(2)
+        """,
+        """
+        variables: x1, x2, x3, x4
+        [x1, x2, x4, x3] in SCS.ComplexPositiveSemidefiniteConeTriangle(2)
+        """,
+    )
+    MOI.Bridges.runtests(
+        SCS.HermitianComplexPSDConeBridge,
+        """
+        variables: x1, x2, x3, x4, x5, x6, x7, x8, x9
+        [x1, x2, x3, x4, x5, x6, x7, x8, x9] in MOI.HermitianPositiveSemidefiniteConeTriangle(3)
+        """,
+        """
+        variables: x1, x2, x3, x4, x5, x6, x7, x8, x9
+        [x1, x2, x7, x3, x4, x8, x5, x9, x6] in SCS.ComplexPositiveSemidefiniteConeTriangle(3)
+        """,
+    )
+    return
+end
+
 end  # module
 
 TestSCS.runtests()


### PR DESCRIPTION
x-ref https://github.com/jump-dev/SCS.jl/pull/330#issuecomment-3425214133

These methods are not necessary: 

 * `function_constants` is used only when getting the function, where as we get the `A` matrix directly.

 * `dot_coefficients` is used only when getting the variable dual, which SCS doesn't support: https://github.com/jump-dev/MathOptInterface.jl/blob/ec8434e5a4813c26a05ce6300b2591b36b82b6f1/src/Utilities/results.jl#L413-L422
 * `set_dot` is used only when computing the dual objective value via the fallback, which we compute directly.

Now there's a different argument for keeping these if/when the set gets added to MOI proper (https://github.com/jump-dev/SCS.jl/pull/330#issuecomment-3425234047), but SCS.jl is not the place for them.